### PR TITLE
Redirect verified users to login page

### DIFF
--- a/frontend/src/pages/EmailVerificationPage.tsx
+++ b/frontend/src/pages/EmailVerificationPage.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useSearchParams, Link } from 'react-router-dom';
-import { useAuth } from '../contexts/AuthContext';
+import { useSearchParams, Link, useNavigate } from 'react-router-dom';
 import LoadingSpinner from '../components/LoadingSpinner';
 
 const EmailVerificationPage: React.FC = () => {
   const [searchParams] = useSearchParams();
-  const { login } = useAuth();
+  const navigate = useNavigate();
   const [verificationStatus, setVerificationStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [message, setMessage] = useState<string>('');
 
@@ -31,7 +30,8 @@ const EmailVerificationPage: React.FC = () => {
 
         if (response.ok && data.success) {
           setVerificationStatus('success');
-          setMessage('Email verified successfully! You can now upload agents.');
+          setMessage('Email verified successfully! Redirecting to login...');
+          setTimeout(() => navigate('/login'), 3000);
         } else {
           setVerificationStatus('error');
           setMessage(data.message || 'Verification failed. Please try again.');
@@ -43,7 +43,7 @@ const EmailVerificationPage: React.FC = () => {
     };
 
     verifyEmail();
-  }, [searchParams]);
+  }, [searchParams, navigate]);
 
   if (verificationStatus === 'loading') {
     return (
@@ -76,16 +76,10 @@ const EmailVerificationPage: React.FC = () => {
               </p>
               <div className="mt-6 space-y-4">
                 <Link
-                  to="/upload"
+                  to="/login"
                   className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
                 >
-                  Upload Your First Agent
-                </Link>
-                <Link
-                  to="/"
-                  className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                >
-                  Browse Agents
+                  Go to Login
                 </Link>
               </div>
             </>


### PR DESCRIPTION
## Summary
- automatically redirect users to login after successful email verification
- simplify success screen to only link to login

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a3cb45608323b4861286445c2fac